### PR TITLE
Fix CI test failures: remove directory name assumptions

### DIFF
--- a/tests/Unit/InstallCommandTest.php
+++ b/tests/Unit/InstallCommandTest.php
@@ -99,22 +99,22 @@ it('installs all skills to all agents in non-interactive mode', function () {
     expect($capturedCalls)->toHaveCount(2);
 
     // First call: turbo package skills
-    expect($capturedCalls[0]['source'])->toEndWith('turbo');
+    expect($capturedCalls[0]['source'])->toEndWith('.ai/skills');
     expect($capturedCalls[0]['skills'])->toContain('laravel-controllers');
     expect($capturedCalls[0]['skills'])->toContain('github-issue');
-    expect($capturedCalls[0]['agents'])->toBe(['claude-code', 'cursor', 'codex']);
+    expect($capturedCalls[0]['agents'])->toBe(['claude-code', 'cursor', 'codex', 'github-copilot']);
 
     // Second call: agent-browser
     expect($capturedCalls[1]['source'])->toBe('vercel-labs/agent-browser');
     expect($capturedCalls[1]['skills'])->toBe(['agent-browser']);
-    expect($capturedCalls[1]['agents'])->toBe(['claude-code', 'cursor', 'codex']);
+    expect($capturedCalls[1]['agents'])->toBe(['claude-code', 'cursor', 'codex', 'github-copilot']);
 });
 
 it('processes templates after installing turbo skills', function () {
     registerTestableInstallCommand([
         'runNpxSkillsAdd' => function ($source) {
             // Only simulate file creation for turbo source (not third-party)
-            if (str_ends_with($source, 'turbo')) {
+            if (str_ends_with($source, '.ai/skills')) {
                 $skillsPath = base_path('.claude/skills/github-issue');
                 File::makeDirectory($skillsPath, 0755, true);
                 File::copyDirectory(
@@ -147,7 +147,7 @@ it('fails when third-party skill installation fails', function () {
     registerTestableInstallCommand([
         'runNpxSkillsAdd' => function ($source) {
             // Turbo skills succeed, third-party fails
-            return str_ends_with($source, 'turbo') ? 0 : 1;
+            return str_ends_with($source, '.ai/skills') ? 0 : 1;
         },
     ]);
 

--- a/tests/Unit/SkillsCommandTest.php
+++ b/tests/Unit/SkillsCommandTest.php
@@ -89,7 +89,7 @@ it('passes package path to npx skills add', function () {
     $this->artisan('turbo:skills', ['--no-interaction' => true])
         ->assertSuccessful();
 
-    expect($capturedPath)->toEndWith('turbo');
+    expect($capturedPath)->toEndWith('.ai/skills');
 });
 
 it('processes templates after npx skills installs', function () {

--- a/tests/Unit/SkillsServiceTest.php
+++ b/tests/Unit/SkillsServiceTest.php
@@ -5,7 +5,8 @@ use Springloaded\Turbo\Services\SkillsService;
 it('returns correct package path', function () {
     $service = app(SkillsService::class);
 
-    expect(basename($service->getPackagePath()))->toBe('turbo');
+    expect($service->getPackagePath())->toBeDirectory()
+        ->and($service->getSkillsSourcePath())->toEndWith('.ai/skills');
 });
 
 it('returns installed skill paths for existing directories', function () {


### PR DESCRIPTION
## Summary

- **Path assertions no longer depend on directory name** — Tests were asserting paths ended with `turbo` (the package dir name), which fails in CI checkout directories and git worktrees. Now asserts against `.ai/skills` which is the actual meaningful path segment.
- **Update agent list in test** — `github-copilot` was added to `getAgentChoices()` but the test still expected only 3 agents.

## Test plan

- [ ] All tests pass locally (40 passed, 1 skipped)
- [ ] CI should now pass regardless of checkout directory name

🤖 Generated with [Claude Code](https://claude.com/claude-code)