### PR TITLE
fix: build multi-arch image and fail install on sandbox error

### DIFF
--- a/.github/workflows/publish-sandbox.yml
+++ b/.github/workflows/publish-sandbox.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -35,6 +38,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: springloadedco/turbo:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -135,7 +135,9 @@ class InstallCommand extends Command
         $this->configureSecrets();
 
         // Step 5: Docker sandbox
-        $this->offerDockerSetup();
+        if (! $this->offerDockerSetup()) {
+            return self::FAILURE;
+        }
 
         $this->newLine();
         $this->info('Turbo installation complete!');
@@ -609,10 +611,10 @@ class InstallCommand extends Command
      * Skips with an informative message when sbx is not installed or when a
      * sandbox for this project already exists.
      */
-    protected function offerDockerSetup(): void
+    protected function offerDockerSetup(): bool
     {
         if (! $this->input->isInteractive()) {
-            return;
+            return true;
         }
 
         if (! $this->sbxAvailable()) {
@@ -620,7 +622,7 @@ class InstallCommand extends Command
             $this->line('Note: sbx CLI not installed. Skipping Docker sandbox.');
             $this->line('  Install with: brew install docker/tap/sbx');
 
-            return;
+            return true;
         }
 
         $sandbox = app(DockerSandbox::class);
@@ -630,7 +632,7 @@ class InstallCommand extends Command
             $this->info("✓ Sandbox '{$sandbox->sandboxName()}' already exists.");
             $this->line('  Run `php artisan turbo:doctor` to verify state.');
 
-            return;
+            return true;
         }
 
         $this->configureDockerImage();
@@ -641,7 +643,7 @@ class InstallCommand extends Command
             $this->newLine();
 
             if (! confirm(label: 'Image is pushed and ready?', default: true)) {
-                return;
+                return true;
             }
         }
 
@@ -653,11 +655,13 @@ class InstallCommand extends Command
             $this->error('Failed to create sandbox.');
             $this->line($createProcess->getErrorOutput());
 
-            return;
+            return false;
         }
 
         $this->info('Preparing sandbox...');
         $sandbox->prepareSandbox();
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
## Summary
Two fixes:

**Multi-arch image build** — The published image only had an `amd64` manifest, so Apple Silicon Macs got `pull access denied` / `no matching manifest for linux/arm64`. Adds QEMU emulation and `platforms: linux/amd64,linux/arm64` to the publish workflow.

**Install status on sandbox failure** — `offerDockerSetup()` returned void, so sandbox creation failures were swallowed and the install printed "Turbo installation complete!" anyway. Now returns `bool` and the install exits with `FAILURE` when sandbox creation fails.

## Test plan
- [ ] `publish-sandbox` CI builds for both `linux/amd64` and `linux/arm64`
- [ ] `turbo:install` on Apple Silicon pulls the arm64 image successfully
- [ ] `turbo:install` with a broken image shows error and does NOT print "installation complete"

🤖 Generated with [Claude Code](https://claude.com/claude-code)