### PR TITLE
fix: resolve the Chromium binary across both Playwright layouts

### DIFF
--- a/.github/workflows/publish-sandbox.yml
+++ b/.github/workflows/publish-sandbox.yml
@@ -6,6 +6,13 @@ on:
     paths:
       - 'Dockerfile'
       - '.github/workflows/publish-sandbox.yml'
+  # Build on PRs too, without pushing. Publishing only from main meant a broken
+  # Dockerfile was merged before anything tried to build it — which is how the
+  # image silently went four months without a successful publish.
+  pull_request:
+    paths:
+      - 'Dockerfile'
+      - '.github/workflows/publish-sandbox.yml'
   workflow_dispatch:
 
 concurrency:
@@ -26,7 +33,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      # A pull request from a fork cannot read the secrets, and does not need
+      # to — it only builds.
       - name: Log in to Docker Hub
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -36,7 +46,9 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
+          # Both architectures are built either way — the amd64 leg is the one
+          # that broke, so a PR that only built arm64 would not have caught it.
+          push: ${{ github.event_name != 'pull_request' }}
           platforms: linux/amd64,linux/arm64
           tags: springloadedco/turbo:latest
           cache-from: type=gha

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,15 @@ RUN COMPOSER_HOME=/opt/composer-global COMPOSER_ALLOW_SUPERUSER=1 \
 # The apt chromium-browser package is a non-functional snap stub on ARM64.
 # Install to /opt/chromium so the agent user can access it (default /root is 700).
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/chromium
+# The extracted directory name is not stable across architectures: amd64 now
+# gets Chrome for Testing (chrome-linux64/), arm64 still gets Playwright's own
+# build (chrome-linux/). Match on the registry directory instead — `chromium-*`
+# is the full browser, `chromium_headless_shell-*` is the shell we don't want —
+# and fail loudly rather than feeding `ln` an empty path.
 RUN npx --yes playwright install --with-deps chromium \
   && chmod -R o+rx /opt/chromium \
-  && CHROMIUM_PATH=$(find /opt/chromium -name chrome -path '*/chrome-linux/*' | head -1) \
+  && CHROMIUM_PATH=$(find /opt/chromium -type f -name chrome -perm -u+x -path '*/chromium-*' | head -1) \
+  && { [ -n "$CHROMIUM_PATH" ] || { echo "no chrome binary under /opt/chromium — Playwright's layout changed" >&2; exit 1; }; } \
   && ln -s "$CHROMIUM_PATH" /usr/local/bin/chromium
 
 # Agent Browser https://agent-browser.dev/installation

--- a/kit/spec.yaml
+++ b/kit/spec.yaml
@@ -233,7 +233,16 @@ commands:
         # needs to write here. Root-owned, it fails with EACCES.
         chown -R 1000:1000 /opt/chromium
         chmod -R o+rX /opt/chromium
-        CHROMIUM_PATH=$(find /opt/chromium -name chrome -path '*/chrome-linux/*' | head -1)
+        # The extracted directory name is not stable across architectures:
+        # amd64 now gets Chrome for Testing (chrome-linux64/), arm64 still gets
+        # Playwright's own build (chrome-linux/). Match on the registry
+        # directory instead — `chromium-*` is the full browser,
+        # `chromium_headless_shell-*` is the shell we don't want.
+        CHROMIUM_PATH=$(find /opt/chromium -type f -name chrome -perm -u+x -path '*/chromium-*' | head -1)
+        # Without this, an empty match reaches `ln` as "no such file or
+        # directory" — a message that says nothing about what actually broke.
+        [ -n "$CHROMIUM_PATH" ] \
+          || { echo "chromium: no chrome binary under /opt/chromium — Playwright's layout changed" >&2; exit 1; }
         ln -sf "$CHROMIUM_PATH" /usr/local/bin/chromium
       user: "0"
       description: Install headless Chromium via Playwright


### PR DESCRIPTION
`publish-sandbox` has been failing since April. The last successful image publish predates 94d25c8, the commit that introduced the Playwright Chromium install — so `springloadedco/turbo:latest` on Docker Hub still ships the apt `chromium-browser` that commit was written to replace.

## The bug

The symlink step matched `*/chrome-linux/*`. Playwright now serves amd64 from **Chrome for Testing**, which extracts to `chrome-linux64/`:

```
Downloading Chrome for Testing 151.0.7922.34 from
  https://cdn.playwright.dev/builds/cft/151.0.7922.34/linux64/chrome-linux64.zip
```

arm64 still gets Playwright's own build in `chrome-linux/`, so only the amd64 leg failed — with `ln: No such file or directory`, which names neither Playwright nor the path.

The same glob was in the kit's install hook, where it is worse: under `set -eu` it fails sandbox creation on any stock amd64 base.

## The fix

Match on the registry directory, which is stable on both architectures — `chromium-<rev>` is the full browser, `chromium_headless_shell-<rev>` is the shell we don't want. An empty match is now a hard error naming the real cause.

Verified against both real layouts, plus a headless-shell-only tree as a negative control.

## Why it went unnoticed

The image only built on pushes to `main`. PRs now run the same build without pushing, on both architectures — **this PR is the first thing to actually verify the fix.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)