### PR TITLE
docs: document the git+ kit reference form

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,6 +184,31 @@ show up in `sbx policy ls` with provenance `kit` (since v0.29.0). Deny always be
 Kit sources are themselves allowlisted and default to `docker.io/` only (v0.34.0+); other registries
 and `git+` URLs need `sbx settings set kit.allowedSources`.
 
+### Kit reference forms
+
+`--kit` accepts more than its help text ("directory, ZIP, or OCI") admits — **git references work**,
+confirmed on v0.37.1:
+
+```
+./my-kit/                                        local directory
+./my-kit.zip                                     local ZIP
+ghcr.io/org/kit:tag                              OCI registry
+oci://ghcr.io/org/kit                            explicit OCI
+git+https://host/org/repo.git                    git over HTTPS
+git+ssh://git@host/org/repo.git                  git over SSH
+git+https://host/org/repo.git#ref=v1.0           at a tag or branch
+git+https://host/org/repo.git#dir=path           a subdirectory
+git+https://host/org/repo.git#ref=v1.0&dir=path  both
+```
+
+Turbo's kit lives in `kit/`, so the reference needs `#dir=kit`. A `ref=` may contain slashes
+(`#ref=feat/some-branch&dir=kit` resolves). Unlike OCI, git references are **not** digest-pinned —
+without `ref=` they track the default branch.
+
+The `kit.allowedSources` entry is the plain `host/org/` prefix (`github.com/springloadedco/`), not
+the `git+https://` URL. When a source is blocked, sbx prints the exact `sbx settings set` command to
+run, so read the error rather than guessing the prefix.
+
 ### Secrets
 
 Secrets are **not** env vars in the VM — the host proxy injects them as HTTP auth headers, so the

--- a/README.md
+++ b/README.md
@@ -48,15 +48,30 @@ sbx run --kit ~/.turbo/kit --template docker.io/springloadedco/turbo:latest clau
 ```
 
 Or reference the published artifact instead of a checkout, using the digest from the
-[latest release](https://github.com/springloadedco/turbo/releases) — remote kit references must be
+[latest release](https://github.com/springloadedco/turbo/releases) — remote OCI references must be
 pinned to a digest, since sbx rejects tags:
 
 ```bash
 sbx run --kit oci://docker.io/springloadedco/turbo-kit@sha256:<digest> claude
 ```
 
-Either way, the reference is only needed when the sandbox is created. After that, re-attach with
-`sbx run --name <sandbox-name>`.
+Or point sbx straight at this repository — no clone, no digest to look up. Remote kit sources are
+allowlisted and default to `docker.io/` only, so this takes a one-time settings change:
+
+```bash
+sbx settings set kit.allowedSources '["docker.io/","github.com/springloadedco/"]'
+sbx run --kit 'git+https://github.com/springloadedco/turbo.git#dir=kit' claude
+```
+
+The allowlist entry is the plain `host/org/` prefix, not the `git+https://` URL. Add `ref=` to pin
+a tag or branch — `#ref=v1.0&dir=kit`. Without it the reference tracks the default branch, which is
+the trade-off against an OCI digest: convenient, but not reproducible.
+
+Any of these still needs `--template docker.io/springloadedco/turbo:latest` to get the prebuilt
+image; without it the kit installs the toolchain itself on first create.
+
+Whichever you use, the reference is only needed when the sandbox is created. After that, re-attach
+with `sbx run --name <sandbox-name>`.
 
 </details>
 


### PR DESCRIPTION
`sbx run --kit` advertises "directory, ZIP, or OCI", but the reference parser also accepts git. That removes both reasons someone would need the installer if they didn't want it — no clone, and no release digest to look up:

```bash
sbx settings set kit.allowedSources '["docker.io/","github.com/springloadedco/"]'
sbx run --kit 'git+https://github.com/springloadedco/turbo.git#dir=kit' claude
```

Documents the full fragment grammar in the README (user-facing) and `CLAUDE.md` (agent-facing), plus the two parts that cost a round of trial and error:

- the `kit.allowedSources` entry is the plain `host/org/` prefix, **not** the `git+https://` URL
- git references are not digest-pinned — without `ref=` they track the default branch

Also narrows the existing "remote kit references must be pinned to a digest" line to OCI, which is what it was about; left alone it contradicts the new section directly below it.

Verified on sbx v0.37.1 — `#dir=kit` and `#ref=<branch>&dir=kit` both resolve (including a branch name with a slash), and a bad ref fails with the underlying git error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)