### PR TITLE
fix: make the Chromium install survive the agent's own Playwright

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+# The Dockerfile has no COPY, so the build context only needs to exist. Sending
+# the repo anyway is wasted upload — and `.git/config` carries the credential
+# `actions/checkout` persists, which a PR-authored Dockerfile could `COPY` and
+# print now that pull requests build this image.
+*

--- a/.github/workflows/publish-sandbox.yml
+++ b/.github/workflows/publish-sandbox.yml
@@ -19,10 +19,20 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      # One expression for "this run publishes", used by both the login step and
+      # `push:` below. Two independent negations of `pull_request` could drift,
+      # and `!= 'pull_request'` is also true for a `workflow_dispatch` off any
+      # branch — which would put unmerged code on the `:latest` tag every user
+      # consumes. Only main publishes; dispatch from a branch still builds.
+      PUBLISH: ${{ github.ref == 'refs/heads/main' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -33,14 +43,35 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      # A pull request from a fork cannot read the secrets, and does not need
-      # to — it only builds.
+      # A run that does not publish has nothing to authenticate — and on
+      # GitHub-hosted runners an unscoped login would *replace* the embedded
+      # Docker Hub credential that makes public base-image pulls exempt from the
+      # anonymous rate limit, so skipping it is also the better default.
       - name: Log in to Docker Hub
-        if: github.event_name != 'pull_request'
+        if: env.PUBLISH == 'true'
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # A multi-platform build is never loaded into the daemon, so building alone
+      # only proves the Dockerfile exits 0 — it cannot catch a `chromium` symlink
+      # pointing at the wrong or unusable binary, which is the failure mode this
+      # image actually has. Load the amd64 leg on its own first so the check
+      # CLAUDE.md prescribes can run *before* anything is published.
+      - name: Build amd64 for the smoke test
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          platforms: linux/amd64
+          tags: springloadedco/turbo:smoke-test
+          cache-from: type=gha
+
+      - name: Verify agent-browser can drive Chromium
+        run: |
+          docker run --rm --user agent springloadedco/turbo:smoke-test \
+            agent-browser batch "open file:///dev/null" "screenshot"
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -48,8 +79,14 @@ jobs:
           context: .
           # Both architectures are built either way — the amd64 leg is the one
           # that broke, so a PR that only built arm64 would not have caught it.
-          push: ${{ github.event_name != 'pull_request' }}
+          # Its layers come from the builder's local cache, populated above.
+          push: ${{ env.PUBLISH }}
           platforms: linux/amd64,linux/arm64
           tags: springloadedco/turbo:latest
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Only publishing runs write the cache. A cache written from a PR is
+          # scoped to `refs/pull/N/merge`: main can never restore it, so the
+          # write buys nothing — while a mode=max two-arch export is ~2.5GB
+          # against a 10GB per-repo quota that evicts by LRU, i.e. PR builds
+          # push out the main-branch entry this job's `cache-from` depends on.
+          cache-to: ${{ env.PUBLISH == 'true' && 'type=gha,mode=max' || '' }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,8 +238,25 @@ baked template, or `host.docker.internal` plus a `Host:` header.
 - The apt `chromium-browser` package on ARM64 Ubuntu is a non-functional snap stub. Chromium comes
   from Playwright into `/opt/chromium`, symlinked to `/usr/local/bin/chromium`, with
   `AGENT_BROWSER_EXECUTABLE_PATH` set.
+- **The extracted browser directory name differs per architecture.** amd64 gets Chrome for Testing
+  in `chrome-linux64/`, arm64 gets Playwright's own build in `chrome-linux/` — it's a per-platform
+  table (`EXECUTABLE_PATHS`) inside playwright-core, so never match on it. Match the *registry*
+  directory (`chromium-<rev>`) instead. This cost four months of failed publishes once already.
+- **`/opt/chromium` must be owned by uid 1000, not merely world-readable.** `PLAYWRIGHT_BROWSERS_PATH`
+  points there and is exported to the agent, so a project pulling its own Playwright version installs
+  *into* it. Root-owned, that fails with EACCES. The kit repairs ownership *before* its early-exit
+  guard precisely so it can fix a template that shipped the symlink over a root-owned tree.
+- **`PLAYWRIGHT_SKIP_BROWSER_GC=1` is load-bearing.** Playwright deletes revisions its `.links`
+  entries no longer reference. Ours is written by a root `npx --yes`, so it points into `/root/.npm`,
+  which uid 1000 cannot read — without the opt-out, the agent's own `playwright install` classifies
+  the link broken and deletes the revision `/usr/local/bin/chromium` resolves through. Install hooks
+  run only at creation, so nothing would repair the dangling symlink.
 - After changing the Dockerfile, verify agent-browser still works:
   ```bash
   docker run --rm --user agent <image> agent-browser batch "open file:///dev/null" "screenshot"
   ```
-  Building needs `cdn.playwright.dev` and `playwright.download.prss.microsoft.com` reachable.
+  CI now runs exactly this on an amd64 `load: true` build — the multi-arch build alone only proves
+  the Dockerfile exits 0, never that the resolved binary launches.
+  Building needs `cdn.playwright.dev`, `playwright.download.prss.microsoft.com` and
+  `storage.googleapis.com` (amd64's Chrome-for-Testing bucket, which `cdn.playwright.dev` 302s to)
+  reachable.

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,16 +28,33 @@ RUN COMPOSER_HOME=/opt/composer-global COMPOSER_ALLOW_SUPERUSER=1 \
 # The apt chromium-browser package is a non-functional snap stub on ARM64.
 # Install to /opt/chromium so the agent user can access it (default /root is 700).
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/chromium
-# The extracted directory name is not stable across architectures: amd64 now
-# gets Chrome for Testing (chrome-linux64/), arm64 still gets Playwright's own
-# build (chrome-linux/). Match on the registry directory instead — `chromium-*`
-# is the full browser, `chromium_headless_shell-*` is the shell we don't want —
-# and fail loudly rather than feeding `ln` an empty path.
+# Playwright prunes revisions its `.links` entries no longer reference. This
+# install runs as root via `npx --yes`, so its link points into /root/.npm,
+# which uid 1000 cannot read — the agent's own `playwright install` would
+# classify the link broken and delete the revision out from under the symlink
+# below. Opting out of the GC keeps /usr/local/bin/chromium resolvable.
+ENV PLAYWRIGHT_SKIP_BROWSER_GC=1
+# The extracted directory name is not stable across architectures: amd64 gets
+# Chrome for Testing (chrome-linux64/), arm64 gets Playwright's own build
+# (chrome-linux/) — a per-platform table in playwright-core, not something to
+# rely on here. Match on the registry directory instead, which is stable on
+# both. `-name chrome` is what excludes the headless shell (its binary is
+# `headless_shell`); `-path` is what makes the match independent of the
+# extracted subdirectory name and keeps other browsers' trees out.
+#
+# Sort by revision and take the newest: `playwright install` only ever adds
+# revision directories, and unsorted `find | head -1` returns readdir order,
+# which is the *oldest* one in practice. Capturing find's output on its own
+# line also lets a genuine find failure abort here instead of arriving as an
+# empty match and being misreported as a layout change.
 RUN npx --yes playwright install --with-deps chromium \
-  && chmod -R o+rx /opt/chromium \
-  && CHROMIUM_PATH=$(find /opt/chromium -type f -name chrome -perm -u+x -path '*/chromium-*' | head -1) \
-  && { [ -n "$CHROMIUM_PATH" ] || { echo "no chrome binary under /opt/chromium — Playwright's layout changed" >&2; exit 1; }; } \
-  && ln -s "$CHROMIUM_PATH" /usr/local/bin/chromium
+  && rm -rf /var/lib/apt/lists/* \
+  && chown -R agent:agent /opt/chromium \
+  && chmod -R o+rX /opt/chromium \
+  && CHROMIUM_MATCHES=$(find /opt/chromium -type f -name chrome -perm -u+x -path '*/chromium-*') \
+  && CHROMIUM_PATH=$(printf '%s\n' "$CHROMIUM_MATCHES" | sort -V | tail -1) \
+  && { [ -n "$CHROMIUM_PATH" ] || { echo "chromium: no chrome binary under /opt/chromium — Playwright's layout changed" >&2; exit 1; }; } \
+  && ln -sf "$CHROMIUM_PATH" /usr/local/bin/chromium
 
 # Agent Browser https://agent-browser.dev/installation
 RUN npm install -g agent-browser

--- a/kit/spec.yaml
+++ b/kit/spec.yaml
@@ -19,6 +19,14 @@ environment:
     # A fixed system path shared by every user fixes that.
     PLAYWRIGHT_BROWSERS_PATH: /opt/chromium
     AGENT_BROWSER_EXECUTABLE_PATH: /usr/local/bin/chromium
+    # Playwright prunes revisions its `.links` entries no longer reference. The
+    # install hook runs as root via `npx --yes`, so its link points into
+    # /root/.npm, which uid 1000 cannot read — the agent's own `playwright
+    # install` would classify the link broken and delete the revision that
+    # AGENT_BROWSER_EXECUTABLE_PATH resolves through. Install hooks only run at
+    # creation, so nothing would repair the dangling symlink for the life of the
+    # sandbox. Opting out of the GC is what keeps it resolvable.
+    PLAYWRIGHT_SKIP_BROWSER_GC: "1"
 
 network:
   allowedDomains:
@@ -221,24 +229,44 @@ commands:
 
     - command: |
         set -eu
+        # Hand the tree to the agent (uid 1000), don't just make it world-readable:
+        # PLAYWRIGHT_BROWSERS_PATH is exported to the agent too, so a project that
+        # pulls its own Playwright version installs *into* this directory and
+        # needs to write here. Root-owned, it fails with EACCES.
+        #
+        # This runs *before* the early exit below on purpose. A template can ship
+        # the symlink over a root-owned registry — the accelerator image does
+        # exactly that — and a guard that only tests the symlink would leave that
+        # tree unwritable forever. Both walks are idempotent and cost milliseconds.
+        if [ -d /opt/chromium ]; then
+            chown -R 1000:1000 /opt/chromium
+            chmod -R o+rX /opt/chromium
+        fi
         [ -x /usr/local/bin/chromium ] && exit 0
         # The apt chromium-browser package is a non-functional snap stub on
         # ARM64, so the browser comes from Playwright instead. /opt keeps it
         # readable by the agent user (root's home is 0700).
         export PLAYWRIGHT_BROWSERS_PATH=/opt/chromium
         npx --yes playwright install --with-deps chromium
-        # Hand the tree to the agent (uid 1000), don't just make it world-readable:
-        # PLAYWRIGHT_BROWSERS_PATH is exported to the agent too, so a project that
-        # pulls its own Playwright version installs *into* this directory and
-        # needs to write here. Root-owned, it fails with EACCES.
         chown -R 1000:1000 /opt/chromium
         chmod -R o+rX /opt/chromium
-        # The extracted directory name is not stable across architectures:
-        # amd64 now gets Chrome for Testing (chrome-linux64/), arm64 still gets
-        # Playwright's own build (chrome-linux/). Match on the registry
-        # directory instead — `chromium-*` is the full browser,
-        # `chromium_headless_shell-*` is the shell we don't want.
-        CHROMIUM_PATH=$(find /opt/chromium -type f -name chrome -perm -u+x -path '*/chromium-*' | head -1)
+        # The extracted directory name is not stable across architectures: amd64
+        # gets Chrome for Testing (chrome-linux64/), arm64 gets Playwright's own
+        # build (chrome-linux/) — a per-platform table in playwright-core, not
+        # something to rely on here. Match on the registry directory instead,
+        # which is stable on both. `-name chrome` is what excludes the headless
+        # shell (its binary is `headless_shell`); `-path` is what makes the match
+        # independent of the extracted subdirectory name and keeps other
+        # browsers' trees out.
+        #
+        # Sort by revision and take the newest: `playwright install` only ever
+        # adds revision directories, and unsorted `find | head -1` returns
+        # readdir order, which is the *oldest* one in practice. Capturing find's
+        # output on its own line also lets a genuine find failure abort here
+        # instead of arriving as an empty match and being misreported below as a
+        # layout change.
+        matches=$(find /opt/chromium -type f -name chrome -perm -u+x -path '*/chromium-*')
+        CHROMIUM_PATH=$(printf '%s\n' "$matches" | sort -V | tail -1)
         # Without this, an empty match reaches `ln` as "no such file or
         # directory" — a message that says nothing about what actually broke.
         [ -n "$CHROMIUM_PATH" ] \


### PR DESCRIPTION
Follow-ups from a deep review of #32. Three defects were reachable only once that PR made the image publishable again — the amd64 leg had been failing since April, so nothing had shipped.

## Image / kit

**Ownership.** The image `chmod`s `/opt/chromium` but never `chown`s it; the kit hook does both. `PLAYWRIGHT_BROWSERS_PATH` is exported to uid 1000, so a project pulling its own Playwright version installs *into* that tree and hits EACCES — on the default `turbo` path. Layering the kit couldn't repair it either: the hook's early exit tests only the symlink, which the image already ships. The chown now runs **before** that guard.

**Garbage collection.** Playwright prunes revisions whose `.links` entry no longer resolves. Both installs run as root via `npx --yes`, so the link points into `/root/.npm` — unreadable to uid 1000, hence "broken". The agent's first `playwright install` would delete the revision `/usr/local/bin/chromium` resolves through, and install hooks only run at creation, so nothing would repair it. Verified in playwright-core: `PLAYWRIGHT_SKIP_BROWSER_GC` gates `_validateInstallationCache`.

**Revision selection.** `find | head -1` returned readdir order — in practice the *oldest* revision. Multiple revisions are expected by design, since the tree is deliberately writable for exactly that. Now sorted by revision, newest wins. Capturing `find` separately also lets a real find failure abort instead of arriving as an empty match misreported as a layout change.

Also corrects the glob comment from #32: `-name chrome` is what excludes the headless shell, whose binary is `chrome-headless-shell` on linux-x64 and `headless_shell` on linux-arm64 — never `chrome`. Confirmed in `EXECUTABLE_PATHS`.

## CI

The gate added in #32 proves only that the Dockerfile exits 0 — a multi-arch build loads no image. An amd64 leg is now built with `load: true` and run through the check CLAUDE.md already prescribes, **before** the publishing build.

`cache-to` was left ungated when `push` was gated: every PR exported ~2.5GB into a `refs/pull/N/merge` scope main can never restore, inside a 10GB LRU quota — evicting the entry main's own `cache-from` depends on.

Also closes a gap where `!= 'pull_request'` was true for a `workflow_dispatch` off any branch, which would have put unmerged code on `:latest`.

## Verified

Both YAML files parse, all six kit hooks pass `dash -n`, `sbx kit validate` is clean, and the env var normalises as a string. The playwright-core claims were checked against the actual bundle, not inferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)